### PR TITLE
Add `namespace_labels` configuration for kubernetes plugin

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -57,6 +57,11 @@ kubernetes [ZONES...] {
 * `kubeconfig` **KUBECONFIG** **CONTEXT** authenticates the connection to a remote k8s cluster using a kubeconfig file. It supports TLS, username and password, or token-based authentication. This option is ignored if connecting in-cluster (i.e. endpoint is not specified).
 * `namespaces` **NAMESPACE [NAMESPACE...]**, only exposes the k8s namespaces listed.
    If this option is omitted all namespaces are exposed
+* `namespace_labels` **EXPRESSION** only expose the records for Kubernetes namespaces that match this label selector.
+   The label selector syntax is described in the
+   [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/). An example that
+   only exposes namespaces labeled as "istio-injection=enabled", would use: 
+   `labels istio-injection=enabled`.
 * `labels` **EXPRESSION** only exposes the records for Kubernetes objects that match this label selector.
    The label selector syntax is described in the
    [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/). An example that

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -61,6 +61,7 @@ type dnsControl struct {
 	client kubernetes.Interface
 
 	selector labels.Selector
+	namespaceSelector labels.Selector
 
 	svcController cache.Controller
 	podController cache.Controller
@@ -91,9 +92,12 @@ type dnsControlOpts struct {
 	initEndpointsCache bool
 	resyncPeriod       time.Duration
 	ignoreEmptyService bool
+
 	// Label handling.
 	labelSelector *meta.LabelSelector
 	selector      labels.Selector
+	namespaceLabelSelector *meta.LabelSelector
+	namespaceSelector labels.Selector
 
 	zones            []string
 	endpointNameMode bool
@@ -104,6 +108,7 @@ func newdnsController(kubeClient kubernetes.Interface, opts dnsControlOpts) *dns
 	dns := dnsControl{
 		client:           kubeClient,
 		selector:         opts.selector,
+		namespaceSelector: opts.namespaceSelector,
 		stopCh:           make(chan struct{}),
 		watched:          make(map[string]struct{}),
 		zones:            opts.zones,
@@ -151,10 +156,12 @@ func newdnsController(kubeClient kubernetes.Interface, opts dnsControlOpts) *dns
 
 	dns.nsLister, dns.nsController = cache.NewInformer(
 		&cache.ListWatch{
-			ListFunc:  namespaceListFunc(dns.client, dns.selector),
-			WatchFunc: namespaceWatchFunc(dns.client, dns.selector),
+			ListFunc:  namespaceListFunc(dns.client, dns.namespaceSelector),
+			WatchFunc: namespaceWatchFunc(dns.client, dns.namespaceSelector),
 		},
-		&api.Namespace{}, opts.resyncPeriod, cache.ResourceEventHandlerFuncs{})
+		&api.Namespace{},
+		opts.resyncPeriod,
+		cache.ResourceEventHandlerFuncs{})
 
 	return &dns
 }

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -377,6 +378,59 @@ func TestServeDNS(t *testing.T) {
 	}
 }
 
+var nsTestCases = []test.Case{
+	// A Service for an "exposed" namespace that "does exist"
+	{
+		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc1.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
+		},
+	},
+	// A service for an "exposed" namespace that "doesn't exist"
+	{
+		Qname: "svc1.nsnoexist.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1551484803 7200 1800 86400 30"),
+		},
+	},
+}
+
+func TestServeNamespaceDNS(t *testing.T) {
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	// if no namespaces are explicitly exposed, then they are all implicitly exposed
+	k.Namespaces = map[string]bool{}
+	ctx := context.TODO()
+
+	for i, tc := range nsTestCases {
+		r := tc.Msg()
+
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d expected no error, got %v", i, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
+		}
+
+		// Before sorting, make sure that CNAMES do not appear after their target records
+		test.CNAMEOrder(t, resp)
+
+		test.SortAndCheck(t, resp, tc)
+	}
+}
+
 var notSyncedTestCases = []test.Case{
 	{
 		// We should get ServerFailure instead of NameError for missing records when we kubernetes hasn't synced
@@ -623,6 +677,9 @@ func (APIConnServeTest) GetNodeByName(name string) (*api.Node, error) {
 func (APIConnServeTest) GetNamespaceByName(name string) (*api.Namespace, error) {
 	if name == "pod-nons" { // handler_pod_verified_test.go uses this for non-existent namespace.
 		return &api.Namespace{}, nil
+	}
+	if name == "nsnoexist" {
+		return nil, fmt.Errorf("namespace not found")
 	}
 	return &api.Namespace{
 		ObjectMeta: meta.ObjectMeta{

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -397,8 +397,8 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 	// PodModeVerified
 	err = errNoItems
 	if wildcard(podname) && !wildcard(namespace) {
-		// If namespace exist, err should be nil, so that we return nodata instead of NXDOMAIN
-		if k.filteredNamespaceExists(namespace) {
+		// If namespace exists, err should be nil, so that we return NODATA instead of NXDOMAIN
+		if k.filteredNamespaceExists(namespace) || k.namespaceExposed(namespace) {
 			err = nil
 		}
 	}
@@ -431,14 +431,6 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 		return nil, errNoItems
 	}
 
-	err = errNoItems
-	if wildcard(r.service) && !wildcard(r.namespace) {
-		// If namespace exist, err should be nil, so that we return nodata instead of NXDOMAIN
-		if k.filteredNamespaceExists(r.namespace) {
-			err = nil
-		}
-	}
-
 	// handle empty service name
 	if r.service == "" {
 		if k.namespaceExposed(r.namespace) || k.filteredNamespaceExists(r.namespace) || wildcard(r.namespace) {
@@ -447,6 +439,14 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 		}
 		// NXDOMAIN
 		return nil, errNoItems
+	}
+
+	err = errNoItems
+	if wildcard(r.service) && !wildcard(r.namespace) {
+		// If namespace exists, err should be nil, so that we return NODATA instead of NXDOMAIN
+		if k.filteredNamespaceExists(r.namespace) || k.namespaceExposed(r.namespace) {
+			err = nil
+		}
 	}
 
 	var (

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -263,6 +263,15 @@ func (k *Kubernetes) InitKubeCache() (err error) {
 		k.opts.selector = selector
 	}
 
+	if k.opts.namespaceLabelSelector != nil {
+		var selector labels.Selector
+		selector, err = meta.LabelSelectorAsSelector(k.opts.namespaceLabelSelector)
+		if err != nil {
+			return fmt.Errorf("unable to create Selector for LabelSelector '%s': %q", k.opts.namespaceLabelSelector, err)
+		}
+		k.opts.namespaceSelector = selector
+	}
+
 	k.opts.initPodCache = k.podMode == podModeVerified
 
 	k.opts.zones = k.Zones
@@ -348,13 +357,15 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 	}
 
 	namespace := r.namespace
+	if !wildcard(namespace) && (!k.namespaceExposed(namespace) || !k.filteredNamespaceExists(namespace)) {
+		return nil, errNoItems
+	}
+
 	podname := r.service
-	zonePath := msg.Path(zone, "coredns")
-	ip := ""
 
 	// handle empty pod name
 	if podname == "" {
-		if k.namespace(namespace) || wildcard(namespace) {
+		if k.namespaceExposed(namespace) || k.filteredNamespaceExists(namespace) || wildcard(namespace) {
 			// NODATA
 			return nil, nil
 		}
@@ -362,6 +373,8 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 		return nil, errNoItems
 	}
 
+	zonePath := msg.Path(zone, "coredns")
+	ip := ""
 	if strings.Count(podname, "-") == 3 && !strings.Contains(podname, "--") {
 		ip = strings.Replace(podname, "-", ".", -1)
 	} else {
@@ -369,7 +382,7 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 	}
 
 	if k.podMode == podModeInsecure {
-		if !wildcard(namespace) && !k.namespace(namespace) { // no wildcard, but namespace does not exist
+		if !wildcard(namespace) && !k.filteredNamespaceExists(namespace) { // no wildcard, but namespace does not exist
 			return nil, errNoItems
 		}
 
@@ -385,14 +398,14 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 	err = errNoItems
 	if wildcard(podname) && !wildcard(namespace) {
 		// If namespace exist, err should be nil, so that we return nodata instead of NXDOMAIN
-		if k.namespace(namespace) {
+		if k.filteredNamespaceExists(namespace) {
 			err = nil
 		}
 	}
 
 	for _, p := range k.APIConn.PodIndex(ip) {
 		// If namespace has a wildcard, filter results against Corefile namespace list.
-		if wildcard(namespace) && !k.namespaceExposed(p.Namespace) {
+		if wildcard(namespace) && (!k.namespaceExposed(p.Namespace) || !k.filteredNamespaceExists(p.Namespace)) {
 			continue
 		}
 
@@ -414,14 +427,26 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 
 // findServices returns the services matching r from the cache.
 func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.Service, err error) {
-	zonePath := msg.Path(zone, "coredns")
+	if !wildcard(r.namespace) && (!k.namespaceExposed(r.namespace) || !k.filteredNamespaceExists(r.namespace)) {
+		return nil, errNoItems
+	}
 
 	err = errNoItems
 	if wildcard(r.service) && !wildcard(r.namespace) {
 		// If namespace exist, err should be nil, so that we return nodata instead of NXDOMAIN
-		if k.namespace(r.namespace) {
+		if k.filteredNamespaceExists(r.namespace) {
 			err = nil
 		}
+	}
+
+	// handle empty service name
+	if r.service == "" {
+		if k.namespaceExposed(r.namespace) || k.filteredNamespaceExists(r.namespace) || wildcard(r.namespace) {
+			// NODATA
+			return nil, nil
+		}
+		// NXDOMAIN
+		return nil, errNoItems
 	}
 
 	var (
@@ -429,16 +454,6 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 		endpointsList     []*object.Endpoints
 		serviceList       []*object.Service
 	)
-
-	// handle empty service name
-	if r.service == "" {
-		if k.namespace(r.namespace) || wildcard(r.namespace) {
-			// NODATA
-			return nil, nil
-		}
-		// NXDOMAIN
-		return nil, errNoItems
-	}
 
 	if wildcard(r.service) || wildcard(r.namespace) {
 		serviceList = k.APIConn.ServiceList()
@@ -449,14 +464,15 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 		endpointsListFunc = func() []*object.Endpoints { return k.APIConn.EpIndex(idx) }
 	}
 
+	zonePath := msg.Path(zone, "coredns")
 	for _, svc := range serviceList {
 		if !(match(r.namespace, svc.Namespace) && match(r.service, svc.Name)) {
 			continue
 		}
 
-		// If namespace has a wildcard, filter results against Corefile namespace list.
+		// If request namespace is a wildcard, filter results against Corefile namespace list.
 		// (Namespaces without a wildcard were filtered before the call to this function.)
-		if wildcard(r.namespace) && !k.namespaceExposed(svc.Namespace) {
+		if wildcard(r.namespace) && (!k.namespaceExposed(svc.Namespace) || !k.filteredNamespaceExists(svc.Namespace)) {
 			continue
 		}
 

--- a/plugin/kubernetes/namespace.go
+++ b/plugin/kubernetes/namespace.go
@@ -1,16 +1,19 @@
 package kubernetes
 
-// namespace checks if namespace n exists in this cluster. This returns true
-// even for non exposed namespaces, see namespaceExposed.
-func (k *Kubernetes) namespace(n string) bool {
-	ns, err := k.APIConn.GetNamespaceByName(n)
+// filteredNamespaceExists checks if namespace exists in this cluster
+// according to any `namespace_labels` plugin configuration specified.
+// Returns true even for namespaces not exposed by plugin configuration,
+// see namespaceExposed.
+func (k *Kubernetes) filteredNamespaceExists(namespace string) bool {
+	ns, err := k.APIConn.GetNamespaceByName(namespace)
 	if err != nil {
 		return false
 	}
-	return ns.ObjectMeta.Name == n
+	return ns.ObjectMeta.Name == namespace
 }
 
-// namespaceExposed returns true when the namespace is exposed.
+// namespaceExposed returns true when the namespace is exposed through the plugin
+// `namespaces` configuration.
 func (k *Kubernetes) namespaceExposed(namespace string) bool {
 	_, ok := k.Namespaces[namespace]
 	if len(k.Namespaces) > 0 && !ok {

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -229,6 +229,18 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 				continue
 			}
 			return nil, c.ArgErr()
+		case "namespace_labels":
+			args := c.RemainingArgs()
+			if len(args) > 0 {
+				namespaceLabelSelectorString := strings.Join(args, " ")
+				nls, err := meta.ParseToLabelSelector(namespaceLabelSelectorString)
+				if err != nil {
+					return nil, fmt.Errorf("unable to parse namespace_label selector value: '%v': %v", namespaceLabelSelectorString, err)
+				}
+				k8s.opts.namespaceLabelSelector = nls
+				continue
+			}
+			return nil, c.ArgErr()
 		case "fallthrough":
 			k8s.Fall.SetZonesFromArgs(c.RemainingArgs())
 		case "upstream":

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -304,6 +304,10 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 		}
 	}
 
+	if len(k8s.Namespaces) != 0 && k8s.opts.namespaceLabelSelector != nil {
+		return nil, c.Errf("namespaces and namespace_labels cannot both be set")
+	}
+
 	return k8s, nil
 }
 

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -188,6 +188,22 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 		},
 		{
+			`kubernetes coredns.local {
+    namespaces foo bar
+    namespace_labels istio-injection=enabled
+}`,
+			true,
+			"Error during parsing: namespaces and namespace_labels cannot both be set",
+			-1,
+			0,
+			defaultResyncPeriod,
+			"",
+			"istio-injection=enabled",
+			podModeDisabled,
+			fall.Zero,
+			nil,
+		},
+		{
 			`kubernetes coredns.local test.local {
     resyncperiod 15m
 	endpoint http://localhost:8080

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -14,16 +14,17 @@ import (
 
 func TestKubernetesParse(t *testing.T) {
 	tests := []struct {
-		input                 string        // Corefile data as string
-		shouldErr             bool          // true if test case is expected to produce an error.
-		expectedErrContent    string        // substring from the expected error. Empty for positive cases.
-		expectedZoneCount     int           // expected count of defined zones.
-		expectedNSCount       int           // expected count of namespaces.
-		expectedResyncPeriod  time.Duration // expected resync period value
-		expectedLabelSelector string        // expected label selector value
-		expectedPodMode       string
-		expectedFallthrough   fall.F
-		expectedUpstreams     []string
+		input                          string        // Corefile data as string
+		shouldErr                      bool          // true if test case is expected to produce an error.
+		expectedErrContent             string        // substring from the expected error. Empty for positive cases.
+		expectedZoneCount              int           // expected count of defined zones.
+		expectedNSCount                int           // expected count of namespaces.
+		expectedResyncPeriod           time.Duration // expected resync period value
+		expectedLabelSelector          string        // expected label selector value
+		expectedNamespaceLabelSelector string        // expected namespace label selector value
+		expectedPodMode                string
+		expectedFallthrough            fall.F
+		expectedUpstreams              []string
 	}{
 		// positive
 		{
@@ -33,6 +34,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -46,6 +48,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -58,6 +61,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -73,6 +77,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -86,6 +91,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			1,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -101,6 +107,7 @@ func TestKubernetesParse(t *testing.T) {
 			2,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -114,6 +121,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			30 * time.Second,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -129,6 +137,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			15 * time.Minute,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -143,6 +152,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"environment=prod",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -157,6 +167,22 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"application=nginx,environment in (production,qa,staging)",
+			"",
+			podModeDisabled,
+			fall.Zero,
+			nil,
+		},
+		{
+			`kubernetes coredns.local {
+    namespace_labels istio-injection=enabled
+}`,
+			false,
+			"",
+			1,
+			0,
+			defaultResyncPeriod,
+			"",
+			"istio-injection=enabled",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -175,6 +201,7 @@ func TestKubernetesParse(t *testing.T) {
 			2,
 			15 * time.Minute,
 			"application=nginx,environment in (production,qa,staging)",
+			"",
 			podModeDisabled,
 			fall.Root,
 			nil,
@@ -190,6 +217,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -203,6 +231,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			-1,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -218,6 +247,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			0 * time.Minute,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -231,6 +261,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			0,
 			0 * time.Second,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -246,6 +277,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			0 * time.Second,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -260,6 +292,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			0 * time.Second,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -273,6 +306,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			0,
 			0 * time.Second,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -289,6 +323,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -303,6 +338,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeInsecure,
 			fall.Zero,
@@ -319,6 +355,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeVerified,
 			fall.Zero,
 			nil,
@@ -333,6 +370,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeVerified,
 			fall.Zero,
@@ -349,6 +387,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.F{Zones: []string{"ip6.arpa.", "inaddr.arpa.", "foo.com."}},
 			nil,
@@ -363,6 +402,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -379,6 +419,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -392,6 +433,7 @@ kubernetes cluster.local`,
 			-1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -407,6 +449,7 @@ kubernetes cluster.local`,
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -421,6 +464,7 @@ kubernetes cluster.local`,
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 			nil,
@@ -434,6 +478,7 @@ kubernetes cluster.local`,
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The current `kubernetes` plugin does not correctly support a `labels` configuration for namespaces. 

This is due the way the API watches are created for a namespace and pods/services/endpoints. A namespace specific label would not be configured on pods/services/endpoints and as a result, trying to specify a label on a namespace restricts watches on pods/services/endpoints that CoreDNS is aware about.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

The `kubernetes` plugin `README.md` documentation has been updated.