### PR TITLE
[plugin][tracer] - Have a consistent spanName

### DIFF
--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -111,6 +111,8 @@ func (t *trace) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	span.SetTag(tagRcode, rcode.ToString(rw.Rcode))
 	span.SetTag(tagServer, metrics.WithServer(ctx))
 	span.SetTag(tagType, req.Type())
+	span.SetTag("_dd1.sr.eausr",1)
+	span.SetTag("_dd1.sr.rapre",float64(1/t.every))
 
 	return status, err
 }

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -24,9 +24,12 @@ import (
 )
 
 const (
-	tagName  = "coredns.io/name"
-	tagType  = "coredns.io/type"
-	tagRcode = "coredns.io/rcode"
+	tagClient = "coredns.client"
+	tagName   = "coredns.name"
+	tagProto  = "coredns.proto"
+	tagRcode  = "coredns.rcode"
+	tagServer = "coredns.server"
+	tagType   = "coredns.type"
 )
 
 type trace struct {
@@ -95,20 +98,19 @@ func (t *trace) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	}
 
 	req := request.Request{W: w, Req: r}
-	span = t.Tracer().StartSpan(spanName(ctx, req))
+	span = t.Tracer().StartSpan("servedns")
 	defer span.Finish()
 
 	rw := dnstest.NewRecorder(w)
 	ctx = ot.ContextWithSpan(ctx, span)
 	status, err := plugin.NextOrFailure(t.Name(), t.Next, ctx, rw, r)
 
+	span.SetTag(tagClient, req.IP())
 	span.SetTag(tagName, req.Name())
-	span.SetTag(tagType, req.Type())
+	span.SetTag(tagProto, req.Proto())
 	span.SetTag(tagRcode, rcode.ToString(rw.Rcode))
+	span.SetTag(tagServer, metrics.WithServer(ctx))
+	span.SetTag(tagType, req.Type())
 
 	return status, err
-}
-
-func spanName(ctx context.Context, req request.Request) string {
-	return "servedns:" + metrics.WithServer(ctx) + " " + req.Name()
 }


### PR DESCRIPTION
This is for -> COMPUTE-153

The current implementation create to many top level trace.
![image](https://user-images.githubusercontent.com/5513509/66491639-1675a400-ea81-11e9-97d3-07e5cf554ef0.png)

This get them back to a manageable number.
And add a new tag to not lose the data expressed in the previous title.
ie: 
```
# New tag name
tagServer = "coredns.io/server"
# Coredns listening server 
metrics.WithServer(ctx)
```

We need to figure out with APM is that issue with top level span is something datadog specific or it's something that all tracer / opentracer would benefit from.
And then push the change upstream