### PR TITLE
Backport upstream trace log level changes

### DIFF
--- a/plugin/trace/README.md
+++ b/plugin/trace/README.md
@@ -7,6 +7,7 @@
 ## Description
 
 With *trace* you enable OpenTracing of how a request flows through CoreDNS.
+Enable *debug* plugin to get logs from the trace plugin.
 
 ## Syntax
 
@@ -84,3 +85,7 @@ trace tracinghost:9411 {
 	client_server
 }
 ~~~
+
+## Also See
+
+See the *debug* plugin for more information about debug logging.

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -10,17 +10,16 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/rcode"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-
-	// Plugin the trace package.
-	_ "github.com/coredns/coredns/plugin/pkg/trace"
+	_ "github.com/coredns/coredns/plugin/pkg/trace" // Plugin the trace package.
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
 	zipkin "github.com/openzipkin-contrib/zipkin-go-opentracing"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const (
@@ -54,7 +53,7 @@ func (t *trace) OnStartup() error {
 		case "zipkin":
 			err = t.setupZipkin()
 		case "datadog":
-			tracer := opentracer.New(tracer.WithAgentAddr(t.Endpoint), tracer.WithServiceName(t.serviceName), tracer.WithDebugMode(true))
+			tracer := opentracer.New(tracer.WithAgentAddr(t.Endpoint), tracer.WithServiceName(t.serviceName), tracer.WithDebugMode(log.D.Value()))
 			t.tracer = tracer
 		default:
 			err = fmt.Errorf("unknown endpoint type: %s", t.EndpointType)


### PR DESCRIPTION
This backports what was done upstream to set the log level to debug when `coredns` itself is running in debug (instead of having the tracer run in debug by default - which fills our logs with the number of traces it regularly flushes).