### PR TITLE
Add 'EntriesByName' coredns file plugin metric

### DIFF
--- a/plugin/file/README.md
+++ b/plugin/file/README.md
@@ -36,6 +36,12 @@ file DBFILE [ZONES... ] {
 
 If you need outgoing zone transfers, take a look at the *transfer* plugin.
 
+## Metrics
+
+If monitoring is enabled (via the *prometheus* plugin) then the following metrics are exported:
+
+- `coredns_file_entries{domain_name:""}` - The number of entries in zone file grouped by domain name..
+
 ## Examples
 
 Load the `example.org` zone from `example.org.signed` and allow transfers to the internet, but send

--- a/plugin/file/metrics.go
+++ b/plugin/file/metrics.go
@@ -14,5 +14,5 @@ var (
 		Subsystem: "file",
 		Name:      "entries",
 		Help:      "The number of entries in zone file grouped by domain name.",
-	}, []string{"dns_name"})
+	}, []string{"domain_name"})
 )

--- a/plugin/file/metrics.go
+++ b/plugin/file/metrics.go
@@ -8,11 +8,11 @@ import (
 )
 
 var (
-	// hostsEntries is the combined number of entries in hosts and Corefile.
+	// zoneFileEntriesByDomain is the number of entries in zone file grouped by domain name.
 	zoneFileEntriesByDomain = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "file",
 		Name:      "entries",
-		Help:      "The combined number of entries in zone file and Corefile.",
+		Help:      "The number of entries in zone file grouped by domain name.",
 	}, []string{"dns_name"})
 )

--- a/plugin/file/metrics.go
+++ b/plugin/file/metrics.go
@@ -1,0 +1,18 @@
+package file
+
+import (
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// hostsEntries is the combined number of entries in hosts and Corefile.
+	zoneFileEntriesByDomain = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "file",
+		Name:      "entries",
+		Help:      "The combined number of entries in zone file and Corefile.",
+	}, []string{"dns_name"})
+)


### PR DESCRIPTION

This PR adds a new metric to the coredns file plugin. This metrics reports the number of records per domain name. We need this to be able to troubleshoot spikes of NXDOMAIN responses that we periodically see in our environment. 